### PR TITLE
Optimize startup time

### DIFF
--- a/replicat/__main__.py
+++ b/replicat/__main__.py
@@ -26,7 +26,8 @@ def _instantiate_backend(backend_type, connection_string, **kwargs):
 
 async def _cmd_handler(args, unknown, error):
     settings = None
-    if args.action in {'init', 'benchmark', 'add-key'}:
+
+    if unknown and args.action in {'init', 'benchmark', 'add-key'}:
         # Assume that the unknown arguments are custom settings. Try to re-parse them
         flat_settings, unknown = utils.parse_cli_settings(unknown)
         if not unknown:

--- a/replicat/utils/__init__.py
+++ b/replicat/utils/__init__.py
@@ -18,25 +18,24 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Optional
 
-import httpx
 from tqdm import tqdm
 
 from .. import __version__, exceptions
 from . import adapters, fs  # noqa
 
 PREFIXES_TABLE = {
-    'k': 1000,
-    'K': 1000,
-    'Ki': 1024,
-    'ki': 1024,
-    'M': 1000**2,
-    'm': 1000**2,
-    'Mi': 1024**2,
-    'mi': 1024**2,
-    'g': 1000**3,
-    'G': 1000**3,
-    'gi': 1024**3,
-    'Gi': 1024**3,
+    'k': 1_000,
+    'K': 1_000,
+    'Ki': 1_024,
+    'ki': 1_024,
+    'M': 1_000**2,
+    'm': 1_000**2,
+    'Mi': 1_024**2,
+    'mi': 1_024**2,
+    'g': 1_000**3,
+    'G': 1_000**3,
+    'gi': 1_024**3,
+    'Gi': 1_024**3,
 }
 UNITS_TABLE = {'B': 1, 'b': Decimal('0.125')}
 HUMAN_SIZE_REGEX = (
@@ -469,24 +468,6 @@ def disable_gc(func):
                 gc.enable()
 
     return _decorator
-
-
-class async_client:
-
-    """Creates and stores an httpx.AsyncClient instance when accessed through
-    the parent object. It should only be accessed from within async methods.
-    """
-
-    def __init__(self, *args, **kwargs):
-        self.args, self.kwargs = args, kwargs
-
-    def __get__(self, instance, owner):
-        try:
-            return self._session
-        except AttributeError:
-            # loop should be picked up automatically
-            self._session = httpx.AsyncClient(*self.args, **self.kwargs)
-            return self._session
 
 
 class DefaultNamespace(SimpleNamespace):

--- a/replicat/utils/adapters.py
+++ b/replicat/utils/adapters.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import cryptography.exceptions
 from cryptography.hazmat.primitives.ciphers import aead
+from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
 
 import _replicat_adapters
 from .. import exceptions
@@ -139,14 +140,16 @@ class scrypt(KDFAdapter):
         if context is None:
             context = b''
 
-        return hashlib.scrypt(
-            pwd,
+        # If we used hashlib's scrypt, we'd need to take care of maxmem limits
+        # ourselves, plus they are small
+        instance = Scrypt(
             n=self.n,
             r=self.r,
             p=self.p,
-            dklen=self.length,
+            length=self.length,
             salt=params + context,
         )
+        return instance.derive(pwd)
 
 
 class blake2b(KDFAdapter, MACAdapter, HashAdapter):

--- a/replicat/utils/adapters.py
+++ b/replicat/utils/adapters.py
@@ -5,14 +5,10 @@ from collections.abc import ByteString, Iterator
 from typing import Optional
 
 import cryptography.exceptions
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import aead
-from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
 
 import _replicat_adapters
 from .. import exceptions
-
-_backend = default_backend()
 
 
 class CipherAdapter(ABC):
@@ -143,15 +139,14 @@ class scrypt(KDFAdapter):
         if context is None:
             context = b''
 
-        instance = Scrypt(
+        return hashlib.scrypt(
+            pwd,
             n=self.n,
             r=self.r,
             p=self.p,
-            length=self.length,
+            dklen=self.length,
             salt=params + context,
-            backend=_backend,
         )
-        return instance.derive(pwd)
 
 
 class blake2b(KDFAdapter, MACAdapter, HashAdapter):


### PR DESCRIPTION
Remove `replicat.utils.async_client`, because it really isn't needed, and because we had to import `httpx` just for that, which actually amounted for ~30-45% of startup time. Also remove `default_backend()` call, because it's simply redundant.