### PR TITLE
Repository.download_objects and the corresponding CLI action

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ There are several available subcommands:
  - `add-key` -- creates a new key for the encrypted repository
  - `delete` -- deletes snapshots by their names
  - `clean` -- performs garbage collection
- - `upload` -- uploads files to the backend (no chunking, no encryption, keeping original names)
+ - `upload-objects` -- uploads objects to the backend (a low-level method)
+ - `download-objects` -- downloads objects from the backend (a low-level method)
 
 > ⚠️ **WARNING**: actions that read from or upload to the repository can safely be run
 > concurrently; however, there are presently no guards in place that would make it safe
@@ -189,13 +190,13 @@ Encrypted repositories require a key and a matching password for every operation
 ## `init` examples
 
 ```bash
-# Unencrypted repository in some/directory. The --encryption none flag disables encryption
+# Unencrypted repository in 'some/directory'. The --encryption none flag disables encryption
 $ replicat init -r some/directory --encryption none
 # Encrypted repository with initial password taken from string.
 # The new key will be printed to stdout
 $ replicat init -r some/directory -p 'password string'
 # Encrypted repository with initial password taken from a file.
-# The new key will be written to path/to/key/file
+# The new key will be written to 'path/to/key/file'
 $ replicat init -r some/directory -P path/to/password/file -o path/to/key/file
 # Specifies the cipher
 $ replicat init -r some/directory -p '...' --encryption.cipher.name chacha20_poly1305
@@ -243,7 +244,6 @@ $ replicat list-snapshots -r some/directory -P path/to/password/file -K path/to/
 $ replicat ls -r some/directory -P path/to/password/file -K path/to/key/file
 ```
 
-
 ## `list-files`/`lf` examples
 
 ```bash
@@ -261,7 +261,7 @@ $ replicat lf -r some/directory \
 ## `restore` examples
 
 ```bash
-# Unlocks the repository and restores the latest versions of all files to target-directory
+# Unlocks the repository and restores the latest versions of all files to 'target-directory'
 $ replicat restore -r some/directory \
     -P path/to/password/file \
     -K path/to/key/file \
@@ -276,7 +276,6 @@ $ replicat restore -r some/directory \
     target-directory
 
 ```
-
 
 ## `add-key` examples
 
@@ -318,23 +317,38 @@ $ replicat delete -r some/directory \
 $ replicat clean -r some/directory -P path/to/password/file -K path/to/key/file
 ```
 
-## `upload` examples
+## `upload-objects` examples
 
 ```bash
-# Uploads files directly to the backend without any additional processing.
+# Uploads local files directly to the repository without any additional processing.
 # File path -> resulting name:
-#   /working/directory/some/file -> some/file
-#   /working/directory/another/file -> another/file
-#   /working/directory/another/directory/another-file -> another/directory/another-file
-#   /absolute/directory/path/with-file -> absolute/directory/path/with-file
-#   /absolute/file -> absolute/file
-/working/directory$ replicat upload -r some:repository \
+#   '/working/directory/some/file' -> 'some/file'
+#   '/working/directory/another/file' -> 'another/file'
+#   '/working/directory/another/directory/another-file' -> 'another/directory/another-file'
+#   '/absolute/directory/path/with-file' -> 'absolute/directory/path/with-file'
+#   '/absolute/file' -> 'absolute/file'
+/working/directory$ replicat upload-objects -r some:repository \
                         some/file \
                         /working/directory/another/directory \
                         /absolute/directory/path \
                         /absolute/file
-# Uploads files that do not yet exist in the repository (only checks the file names)
-$ replicat upload -r some:repository --skip-existing some/file some/directory
+# Uploads local files that do not yet exist in the repository (only checks the file names)
+$ replicat upload-objects -r some:repository --skip-existing some/file some/directory
+```
+
+## `download-objects` examples
+
+```bash
+# Downloads all objects from the repository directly to the current working directory without
+# any additional processing
+$ replicat download-objects -r some:repository
+# Same, but it downloads objects to 'different/directory' instead
+$ replicat download-objects -r some:repository different/directory
+# Same, but it skips objects that already exist locally (only checks the file names)
+$ replicat download-objects -r some:repository --skip-existing different/directory
+# Downloads objects whose names match the -O regex (e.g. all objects below the 'data'
+# directory on the repository) to the current working directory, skipping existing objects
+$ replicat download-objects -r some:repository -O '^data/' -S
 ```
 
 ## Check version

--- a/replicat/__main__.py
+++ b/replicat/__main__.py
@@ -53,9 +53,16 @@ async def _cmd_handler(args, unknown, error):
         )
     elif args.action == 'benchmark':
         await repository.benchmark(args.name, settings=settings)
-    elif args.action == 'upload':
-        await repository.upload(
+    elif args.action == 'upload-objects':
+        await repository.upload_objects(
             args.path, rate_limit=args.rate_limit, skip_existing=args.skip_existing
+        )
+    elif args.action == 'download-objects':
+        await repository.download_objects(
+            path=args.path,
+            object_regex=args.objects_regex,
+            rate_limit=args.rate_limit,
+            skip_existing=args.skip_existing,
         )
     elif args.action == 'add-key':
         if args.shared:

--- a/replicat/backends/base.py
+++ b/replicat/backends/base.py
@@ -33,6 +33,10 @@ class Backend(abc.ABC):
         return b''
 
     @abc.abstractmethod
+    async def download_stream(self, name, stream):
+        return None
+
+    @abc.abstractmethod
     async def list_files(self, prefix=''):
         """Get the list of files from the backend. Restricts the results to
         non-deleted files starting with this prefix. The return value can be a

--- a/replicat/backends/local.py
+++ b/replicat/backends/local.py
@@ -67,6 +67,18 @@ class Local(Backend):
         return (self.path / name).read_bytes()
 
     @backoff_on_oserror
+    def download_stream(self, name, stream):
+        file = (self.path / name).open('rb')
+        length = os.fstat(file.fileno()).st_size
+        try:
+            stream.truncate(length)
+            with file:
+                shutil.copyfileobj(file, stream)
+        except:
+            stream.seek(0)
+            raise
+
+    @backoff_on_oserror
     def list_files(self, prefix=''):
         path_length = len(str(self.path))
         # pathlib strips the trailing slash from paths; we don't want that here

--- a/replicat/tests/conftest.py
+++ b/replicat/tests/conftest.py
@@ -6,10 +6,10 @@ from replicat.utils.compat import Random
 
 
 @pytest.fixture
-def local_backend(tmpdir):
-    return local.Client(tmpdir / Random().randbytes(4).hex())
+def local_backend(tmp_path):
+    return local.Client(tmp_path / Random().randbytes(4).hex())
 
 
 @pytest.fixture
-def local_repo(local_backend, tmpdir):
-    return Repository(local_backend, concurrent=5, cache_directory=tmpdir / '.cache')
+def local_repo(local_backend, tmp_path):
+    return Repository(local_backend, concurrent=5, cache_directory=tmp_path / '.cache')


### PR DESCRIPTION
 - Add the new `Repository.download_objects` low-level method and the corresponding CLI action.
 - Rename the `Repository.upload` low-level method and the `upload` CLI action to `upload_objects` and `upload-objects` respectively.
 - Tidy up the README and wrappers for backend methods.