### PR TITLE
Remove rate limiter from download-objects

### DIFF
--- a/replicat/__main__.py
+++ b/replicat/__main__.py
@@ -61,7 +61,6 @@ async def _cmd_handler(args, unknown, error):
         await repository.download_objects(
             path=args.path,
             object_regex=args.objects_regex,
-            rate_limit=args.rate_limit,
             skip_existing=args.skip_existing,
         )
     elif args.action == 'list-objects':

--- a/replicat/utils/__init__.py
+++ b/replicat/utils/__init__.py
@@ -236,9 +236,6 @@ def make_main_parser(*parent_parsers):
     download_objects_parser.add_argument(
         '-O', '--objects-regex', help='Regex to filter objects'
     )
-    download_objects_parser.add_argument(
-        '-L', '--limit-rate', dest='rate_limit', type=human_to_bytes
-    )
     download_objects_parser.add_argument('-S', '--skip-existing', action='store_true')
 
     list_objects_parser = subparsers.add_parser('list-objects', parents=parent_parsers)


### PR DESCRIPTION
Remove the `-L`/`--limit-rate` CLI argument of download-objects, because

 - rate limiter is not advertised, is not reliable, and is certainly not covered by tests
 - download-objects doesn't use it anyway
 - it'll take some effort to implement the rate limiter the right way, and I'd rather not delay the 1.3.0 release. It should be done in 1.4.0