### PR TITLE
File hash and more hash adapters

### DIFF
--- a/replicat/repository.py
+++ b/replicat/repository.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from decimal import Decimal
 from functools import cached_property
 from pathlib import Path
-from typing import Any, ByteString, Dict, Iterator, List, NamedTuple, Optional
+from typing import Any, ByteString, Dict, Iterator, List, NamedTuple, Optional, Tuple
 
 from sty import ef, fg
 from tqdm import tqdm
@@ -74,7 +74,7 @@ class _SnapshotState:
     bytes_reused: int = 0
     chunk_counter: int = 0
     current_file: Optional[_SnapshotFile] = None
-    files: List[_SnapshotFile] = dataclasses.field(default_factory=list)
+    files: List[Tuple[int, _SnapshotFile]] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass(repr=False, frozen=True)
@@ -1102,7 +1102,7 @@ class Repository:
                     while True:
                         chunk = source_file.read(chunk_size)
                         state.bytes_with_padding += len(chunk)
-                        file.stream_end = state.bytes_with_padding
+                        file.stream_end += len(chunk)
                         hasher.feed(chunk)
                         yield chunk
 

--- a/replicat/repository.py
+++ b/replicat/repository.py
@@ -1610,7 +1610,7 @@ class Repository:
 
     async def upload_objects(self, paths, *, rate_limit=None, skip_existing=False):
         self.display_status('Collecting files')
-        files = self._flatten_paths(paths)
+        files = self._flatten_resolve_paths(paths)
         if not files:
             logger.info('No files found, nothing to do')
             return

--- a/replicat/utils/__init__.py
+++ b/replicat/utils/__init__.py
@@ -321,7 +321,15 @@ def parse_cli_settings(args_list):
 
 def adapter_from_config(name, **kwargs):
     adapter_type = getattr(adapters, name)
-    bound_args = inspect.signature(adapter_type).bind(**kwargs)
+    signature = inspect.signature(adapter_type)
+
+    try:
+        bound_args = signature.bind(**kwargs)
+    except TypeError as e:
+        raise exceptions.ReplicatError(
+            f'Invalid configuration for adapter {name}'
+        ) from e
+
     bound_args.apply_defaults()
     adapter_args = bound_args.arguments
     return adapter_type, adapter_args

--- a/replicat/utils/adapters.py
+++ b/replicat/utils/adapters.py
@@ -63,9 +63,11 @@ class MACAdapter(ABC):
 
 
 class IncrementalHasher(ABC):
+    @abstractmethod
     def feed(self, data: bytes) -> None:
         return None
 
+    @abstractmethod
     def digest(self) -> bytes:
         return b''
 

--- a/replicat/utils/adapters.py
+++ b/replicat/utils/adapters.py
@@ -62,11 +62,23 @@ class MACAdapter(ABC):
         return b''
 
 
+class IncrementalHasher(ABC):
+    def feed(self, data: bytes) -> None:
+        return None
+
+    def digest(self) -> bytes:
+        return b''
+
+
 class HashAdapter(ABC):
     @abstractmethod
     def digest(self, data: bytes) -> bytes:
         """Compute the hash digest from data"""
         return b''
+
+    @abstractmethod
+    def incremental_hasher(self) -> IncrementalHasher:
+        raise NotImplementedError
 
 
 class ChunkerAdapter(ABC):
@@ -87,9 +99,20 @@ class ChunkerAdapter(ABC):
         chunk_iterator: Iterator[ByteString],
         *,
         params: Optional[ByteString] = None,
-    ):
+    ) -> Iterator[bytes]:
         """Re-chunk the incoming stream of bytes using the provided params"""
         yield b''
+
+
+class HashlibIncrementalHasher(IncrementalHasher):
+    def __init__(self, hash_instance):
+        self.instance = hash_instance
+
+    def feed(self, data: bytes) -> None:
+        self.instance.update(data)
+
+    def digest(self) -> bytes:
+        return self.instance.digest()
 
 
 class AEADCipherAdapterMixin(CipherAdapter):
@@ -181,6 +204,35 @@ class blake2b(KDFAdapter, MACAdapter, HashAdapter):
 
     def digest(self, data):
         return hashlib.blake2b(data, digest_size=self.digest_size).digest()
+
+    def incremental_hasher(self):
+        return HashlibIncrementalHasher(hashlib.blake2b(digest_size=self.digest_size))
+
+
+class sha2(HashAdapter):
+    def __init__(self, *, bits=256):
+        if bits not in (224, 256, 384, 512):
+            raise ValueError('Invalid digest size')
+        self._hasher_class = getattr(hashlib, f'sha{bits}')
+
+    def digest(self, data):
+        return self._hasher_class(data).digest()
+
+    def incremental_hasher(self):
+        return HashlibIncrementalHasher(self._hasher_class())
+
+
+class sha3(HashAdapter):
+    def __init__(self, *, bits=256):
+        if bits not in (224, 256, 384, 512):
+            raise ValueError('Invalid digest size')
+        self._hasher_class = getattr(hashlib, f'sha3_{bits}')
+
+    def digest(self, data):
+        return self._hasher_class(data).digest()
+
+    def incremental_hasher(self):
+        return HashlibIncrementalHasher(self._hasher_class())
 
 
 class gclmulchunker(ChunkerAdapter):


### PR DESCRIPTION
- Store hash digests of whole files in snapshots (in addition to storing hash digests of chunks).
- Add hash adapters for SHA2 and SHA3.
- Actually meaningful optimisations.